### PR TITLE
[ feat ] 할일 목록을 props callback으로 조작후 다시 props로 내려주는 기능 개발

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ export default [
       ...react.configs['jsx-runtime'].rules,
       ...reactHooks.configs.recommended.rules,
       'react/jsx-no-target-blank': 'off',
+      'react/prop-types': 'off',
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,23 +12,28 @@ function fetchTodos() {
   return result;
 }
 
-function App() {
-  const [todos, setTodos] = useState(fetchTodos());
-  useEffect(() => {
-    const storedTodos = fetchTodos();
-    setTodos(storedTodos);
-}, []);
- 
-
- 
+  function App() {
+    const [todos, setTodos] = useState(fetchTodos());
+    useEffect(() => {
+      const storedTodos = fetchTodos();
+      setTodos(storedTodos);
+  }, []);
   
-
-
+  const handleRemove = (todo, index) => {
+    const result = todos.filter(todoItem => {
+        if (todoItem !== todo) {
+        return true;
+        }
+    })
+    setTodos(result);
+    localStorage.removeItem(result);
+  }
+ 
   return (
     <div>
       <TodoHeader />
       <TodoInput />
-      <TodoList todos={todos} />
+      <TodoList todos={todos} onTodoRemove={handleRemove} />
     </div>
   )
 }

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -1,31 +1,12 @@
-import { useEffect, useState } from "react";
-
-
-
-function TodoList({todos}) {
-    
-   
-    
-    const handleRemove = (todo, index) => {
-        const result = todos.filter(todoItem => {
-            if (todoItem !== todo) {
-            return true;
-            }
-        })
-        setTodos(result);
-        localStorage.removeItem(result);
-    }
+function TodoList({todos, onTodoRemove}) {
   return (
     <ul>
-       
-        {
-        // eslint-disable-next-line react/prop-types
-        todos.map((todo, index) => (
+        {todos.map((todo, index) => (
             <li key={index}>
             <span>
                 {todo}
             </span>
-            <button onClick={() => handleRemove(todo, index)}>remove</button>
+            <button onClick={() => onTodoRemove(todo, index)}>remove</button>
             </li>
         ))}
     </ul>


### PR DESCRIPTION
#18
- [x] 할일 목록 삭제를 담당하는 함수를 App.js로 이동
- [x] TodoList 컴포넌트의 props로 handleremove state 내림
- [x] TodoList 컴포넌트에서 remove 버튼 클릭시 callback으로 App.js의 handleRemove 함수가 실행됨

스크린샷
![image](https://github.com/user-attachments/assets/77d84cee-07e3-498f-b5ca-692a64d96fd0)
![image](https://github.com/user-attachments/assets/50ba6d5f-37f6-473d-a5ba-8faf60e6166d)
